### PR TITLE
Fix abuse score defaults

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -635,7 +635,7 @@ impl<T: HttpClient> Client<T> {
     ) -> Result<()> {
         use hmac::{Hmac, Mac};
 
-        match signature.split_once("=") {
+        match signature.split_once('=') {
             Some(("sha1", tag)) if tag.is_ascii() && tag.len() == 40 => {
                 let mut mac = Hmac::<sha1::Sha1>::new_from_slice(webhook_secret.as_bytes())
                     .map_err(|err| Error::Server(err.to_string()))?;

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -250,6 +250,7 @@ pub struct AbuseScore {
     /// A list of the most significant reasons for the score and the values associated with the
     /// user. The included values will vary based on the user. Includes related users in the
     /// details object when applicable.
+    #[serde(default)]
     pub reasons: Vec<AbuseScoreReason>,
 }
 


### PR DESCRIPTION
Sift abuse scores may be returned without a reasons array included.