### PR TITLE
Add changes from December 2022 changelog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = { version = "0.11", optional = true, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-serde_with = "2.0"
+serde_with = "3.0"
 sha1 = { version = "0.10", optional = true }
 thiserror = { version = "1.0" }
 tracing = "0.1"

--- a/src/events/complex_field_types.rs
+++ b/src/events/complex_field_types.rs
@@ -760,6 +760,67 @@ pub struct CreditPoint {
     pub extra: Option<serde_json::Value>,
 }
 
+/// The digital order field type represents a digital asset which can be part of a cryptocurrency
+/// or digital asset transaction.
+///
+/// The value must be a nested object with the appropriate asset subfields. Generally used in the
+/// [CreateOrder](super::Event::CreateOrder), [UpdateOrder](super::Event::UpdateOrder), or
+/// [Transaction](super::Event::Transaction) events.
+///
+/// Please note that digital order cannot be used with `item` or `booking`.
+///
+/// ## Examples
+///
+/// ```
+/// use sift_science::events::{
+///     DigitalOrder, DigitalOrderAssetType, DigitalOrderType,
+/// };
+///
+/// let order = DigitalOrder {
+///     digital_asset: "BTC".to_string(),
+///     pair: Some("BTC_USD".to_string()),
+///     asset_type: Some(DigitalOrderAssetType::Crypto),
+///     order_type: Some(DigitalOrderType::Market),
+///     volume: Some("6.0".to_string()),
+///     extra: None,
+/// };
+/// ```
+///
+/// API Docs: <https://sift.com/developers/docs/curl/events-api/complex-field-types/digital-order>
+///
+/// [Event]: crate::events::Event
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DigitalOrder {
+    /// The trading name of the asset.
+    #[serde(rename = "$digital_asset")]
+    pub digital_asset: String,
+
+    /// Trading pair symbol representing the conversion of one currency to another.
+    ///
+    /// For example, `"BTC_USD"` represents moving bitcoin to US dollars.
+    #[serde(rename = "$pair")]
+    pub pair: Option<String>,
+
+    /// Any digital asset that has value or established ownership.
+    #[serde(rename = "$asset_type")]
+    pub asset_type: Option<DigitalOrderAssetType>,
+
+    /// Any digital asset that has value or established ownership.
+    #[serde(rename = "$order_type")]
+    pub order_type: Option<DigitalOrderType>,
+
+    /// The amount or quantity of the digital asset.
+    ///
+    /// This should be a string representation of a double value.
+    #[serde(rename = "$volume")]
+    pub volume: Option<String>,
+
+    /// Any extra non-reserved fields to be recorded with the digital order.
+    #[serde(flatten)]
+    pub extra: Option<serde_json::Value>,
+}
+
 /// Monetary discounts that are associated with a promotion.
 ///
 /// (e.g. $25 off an order of $100 or more, 10% off, etc). Discounts are usually used for
@@ -962,7 +1023,7 @@ pub struct Item {
 pub struct MerchantProfile {
     /// The internal identifier for the merchant or seller providing the good or service.
     #[serde(rename = "$merchant_id")]
-    pub merchant_id: Option<String>,
+    pub merchant_id: String,
 
     /// The merchant category code follows the 4-digit ISO code.
     ///
@@ -1085,6 +1146,14 @@ pub struct PaymentMethod {
     /// the reason for the decline.
     #[serde(rename = "$decline_reason_code")]
     pub decline_reason_code: Option<String>,
+
+    /// The value entered to identify the Wallet used for the payment.
+    #[serde(rename = "$wallet_address")]
+    pub wallet_address: Option<String>,
+
+    /// The type of wallet used in the payment.
+    #[serde(rename = "$wallet_type")]
+    pub wallet_type: Option<WalletType>,
 
     /// Payer ID returned by Paypal.
     #[serde(rename = "$paypal_payer_id")]
@@ -1293,4 +1362,80 @@ pub struct Segment {
     /// Any extra non-reserved fields to be recorded with the segment.
     #[serde(flatten)]
     pub extra: Option<serde_json::Value>,
+}
+
+/// Any digital asset that has value or established ownership.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum DigitalOrderAssetType {
+    /// Coin assets
+    #[serde(rename = "$coin")]
+    Coin,
+
+    /// Comodity assets
+    #[serde(rename = "$commodity")]
+    Commodity,
+
+    /// Crypto assets
+    #[serde(rename = "$crypto")]
+    Crypto,
+
+    /// Fiat assets
+    #[serde(rename = "$fiat")]
+    Fiat,
+
+    /// Token assets
+    #[serde(rename = "$token")]
+    Token,
+
+    /// Stock assets
+    #[serde(rename = "$stock")]
+    Stock,
+
+    /// Bond assets
+    #[serde(rename = "$bond")]
+    Bond,
+}
+
+/// The type of trade or exchange being made.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum DigitalOrderType {
+    /// Limit orders
+    #[serde(rename = "$limit")]
+    Limit,
+
+    /// Market orders
+    #[serde(rename = "$market")]
+    Market,
+
+    /// Stop limit orders
+    #[serde(rename = "$stop_limit")]
+    StopLimit,
+
+    /// Stop loss orders
+    #[serde(rename = "$stop_loss")]
+    StopLoss,
+
+    /// Take profit orders
+    #[serde(rename = "$take_profit")]
+    TakeProfit,
+
+    /// Take profit limit orders
+    #[serde(rename = "$take_profit_limit")]
+    TakeProfitLimit,
+}
+
+/// The type of wallet used in the payment.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum WalletType {
+    /// Crypto currency wallet
+    #[serde(rename = "$crypto")]
+    Crypto,
+
+    /// Digital wallet
+    #[serde(rename = "$digital")]
+    Digital,
+
+    /// Fiat wallet
+    #[serde(rename = "$fiat")]
+    Fiat,
 }

--- a/src/events/reserved_events.rs
+++ b/src/events/reserved_events.rs
@@ -1,8 +1,8 @@
 use crate::common::{deserialize_opt_ms, serialize_opt_ms};
 use crate::events::{
     complex_field_types::{
-        Address, App, Booking, Browser, Image, Item, MerchantProfile, OrderedFrom, PaymentMethod,
-        Promotion,
+        Address, App, Booking, Browser, DigitalOrder, Image, Item, MerchantProfile, OrderedFrom,
+        PaymentMethod, Promotion,
     },
     reserved_fields::*,
     AbuseType, Micros,
@@ -1351,9 +1351,17 @@ pub struct OrderProperties {
     #[serde(rename = "$user_email")]
     pub user_email: Option<String>,
 
-    /// Total transaction amount in micros in the base unit of the $currency_code. 1 cent = 10,000
-    /// micros. $1.23 USD = 123 cents = 1,230,000 micros. For currencies without cents of
-    /// fractional denominations, like the Japanese Yen, use 1 JPY = 1000000 micros.
+    /// Phone number of the user.
+    ///
+    /// This phone number will be used to send One-Time Password (OTP) when required. The phone
+    /// number should be in E.164 format including + and a country code.
+    #[serde(rename = "$verification_phone_number")]
+    pub verification_phone_number: Option<String>,
+
+    /// Total transaction amount in micros in the base unit of the $currency_code.
+    ///
+    /// 1 cent = 10,000 micros. $1.23 USD = 123 cents = 1,230,000 micros. For currencies without
+    ///   cents of fractional denominations, like the Japanese Yen, use 1 JPY = 1000000 micros.
     #[serde(rename = "$amount")]
     pub amount: Option<Micros>,
 
@@ -1456,6 +1464,13 @@ pub struct OrderProperties {
     /// The details about the merchant or seller providing the goods or service.
     #[serde(rename = "$merchant_profile")]
     pub merchant_profile: Option<MerchantProfile>,
+
+    /// The list of digital orders made.
+    ///
+    /// A digital order represents a digital asset which can be part of a cryptocurrency or digital
+    /// asset transaction. Note: cannot be used in conjunction with `items` or `bookings`.
+    #[serde(rename = "$digital_orders")]
+    pub digital_orders: Vec<DigitalOrder>,
 
     /// Any extra non-reserved fields to be recorded with the event.
     #[serde(flatten)]
@@ -1804,6 +1819,13 @@ pub struct TransactionProperties {
     #[serde(rename = "$user_email")]
     pub user_email: Option<String>,
 
+    /// Phone number of the user.
+    ///
+    /// This phone number will be used to send One-Time Password (OTP) when required. The phone
+    /// number should be in E.164 format including + and a country code
+    #[serde(rename = "$verification_phone_number")]
+    pub verification_phone_number: Option<String>,
+
     /// The type of transaction being recorded.
     #[serde(rename = "$transaction_type")]
     pub transaction_type: Option<TransactionType>,
@@ -1933,6 +1955,21 @@ pub struct TransactionProperties {
     /// The address to the specific physical location of the person receiving a transaction.
     #[serde(rename = "$received_address")]
     pub received_address: Option<Address>,
+
+    /// The list of digital orders made.
+    ///
+    /// A digital order represents a digital asset which can be part of a cryptocurrency or digital
+    /// asset transaction.
+    #[serde(rename = "$digital_orders")]
+    pub digital_orders: Vec<DigitalOrder>,
+
+    /// The wallet ID or address of the person receiving a crypto payment.
+    #[serde(rename = "$receiver_wallet_address")]
+    pub receiver_wallet_address: Option<String>,
+
+    /// Use `true` or `false` to indicate if the recipient is on an external platform.
+    #[serde(rename = "$receiver_external_address")]
+    pub receiver_external_address: Option<bool>,
 
     /// Any extra non-reserved fields to be recorded with the event.
     #[serde(flatten)]

--- a/src/events/reserved_fields.rs
+++ b/src/events/reserved_fields.rs
@@ -450,6 +450,10 @@ pub enum PaymentType {
     #[serde(rename = "$crypto_currency")]
     CryptoCurrency,
 
+    /// Debit Card
+    #[serde(rename = "$debit_card")]
+    DebitCard,
+
     /// Digital wallet
     #[serde(rename = "$digital_wallet")]
     DigitalWallet,
@@ -481,6 +485,10 @@ pub enum PaymentType {
     /// Points
     #[serde(rename = "$points")]
     Points,
+
+    /// Prepaid Card
+    #[serde(rename = "$prepaid_card")]
+    PrepaidCard,
 
     /// Store credit
     #[serde(rename = "$store_credit")]


### PR DESCRIPTION
API: Added fields $wallet_address and $wallet_type to $payment_method field.

API: Added $digital_order complex field which should be used in $create_order, $update_order and $transaction events.

API: Added fields $receiver_wallet_address and $receiver_external_address to $transaction event.